### PR TITLE
decouple client certificates from authentication

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -11,6 +11,7 @@ import android.text.TextWatcher;
 import android.text.method.DigitsKeyListener;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.Button;
@@ -70,7 +71,6 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     private TextInputEditText mUsernameView;
     private TextInputEditText mPasswordView;
     private ClientCertificateSpinner mClientCertificateSpinner;
-    private TextView mClientCertificateLabelView;
     private TextInputLayout mPasswordLayoutView;
     private TextInputEditText mServerView;
     private TextInputEditText mPortView;
@@ -84,6 +84,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     private TextInputEditText mWebdavPathPrefixView;
     private TextInputEditText mWebdavAuthPathView;
     private TextInputEditText mWebdavMailboxPathView;
+    private ViewGroup mAllowClientCertificateView;
     private Button mNextButton;
     private Account mAccount;
     private boolean mMakeDefault;
@@ -124,7 +125,6 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
         mUsernameView = findViewById(R.id.account_username);
         mPasswordView = findViewById(R.id.account_password);
         mClientCertificateSpinner = findViewById(R.id.account_client_certificate_spinner);
-        mClientCertificateLabelView = findViewById(R.id.account_client_certificate_label);
         mPasswordLayoutView = findViewById(R.id.account_password_layout);
         mServerView = findViewById(R.id.account_server);
         mPortView = findViewById(R.id.account_port);
@@ -140,6 +140,8 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
         mCompressionWifi = findViewById(R.id.compression_wifi);
         mCompressionOther = findViewById(R.id.compression_other);
         mSubscribedFoldersOnly = findViewById(R.id.subscribed_folders_only);
+        mAllowClientCertificateView = findViewById(R.id.account_allow_client_certificate);
+
         TextInputLayout serverLayoutView = findViewById(R.id.account_server_layout);
 
         mNextButton.setOnClickListener(this);
@@ -290,6 +292,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
             mSecurityTypeView.setSelection(mCurrentSecurityTypeViewPosition, false);
 
             updateAuthPlainTextFromSecurityType(settings.connectionSecurity);
+            updateViewFromSecurity();
 
             mCompressionMobile.setChecked(mAccount.useCompression(NetworkType.MOBILE));
             mCompressionWifi.setChecked(mAccount.useCompression(NetworkType.WIFI));
@@ -357,12 +360,12 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 }
 
                 updateViewFromAuthType();
+                updateViewFromSecurity();
                 validateFields();
                 AuthType selection = getSelectedAuthType();
 
-                // Have the user select (or confirm) the client certificate
-                if (AuthType.EXTERNAL == selection) {
-
+               // Have the user select the client certificate if not already selected
+               if ((AuthType.EXTERNAL == selection) && (mClientCertificateSpinner.getAlias() == null)) {
                     // This may again invoke validateFields()
                     mClientCertificateSpinner.chooseCertificate();
                 } else {
@@ -413,14 +416,25 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
 
             // hide password fields, show client certificate fields
             mPasswordLayoutView.setVisibility(View.GONE);
-            mClientCertificateLabelView.setVisibility(View.VISIBLE);
-            mClientCertificateSpinner.setVisibility(View.VISIBLE);
         } else {
 
             // show password fields, hide client certificate fields
             mPasswordLayoutView.setVisibility(View.VISIBLE);
-            mClientCertificateLabelView.setVisibility(View.GONE);
-            mClientCertificateSpinner.setVisibility(View.GONE);
+        }
+    }
+
+
+    /**
+     * Shows/hides client certificate spinner
+     */
+    private void updateViewFromSecurity() {
+        ConnectionSecurity security = getSelectedSecurity();
+        boolean isUsingTLS = ((ConnectionSecurity.SSL_TLS_REQUIRED  == security) || (ConnectionSecurity.STARTTLS_REQUIRED == security));
+
+        if (isUsingTLS) {
+            mAllowClientCertificateView.setVisibility(View.VISIBLE);
+        } else {
+            mAllowClientCertificateView.setVisibility(View.GONE);
         }
     }
 
@@ -452,12 +466,14 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
             mAuthTypeView.setSelection(mCurrentAuthTypeViewPosition, false);
             mAuthTypeView.setOnItemSelectedListener(onItemSelectedListener);
             updateViewFromAuthType();
+            updateViewFromSecurity();
 
             onItemSelectedListener = mSecurityTypeView.getOnItemSelectedListener();
             mSecurityTypeView.setOnItemSelectedListener(null);
             mSecurityTypeView.setSelection(mCurrentSecurityTypeViewPosition, false);
             mSecurityTypeView.setOnItemSelectedListener(onItemSelectedListener);
             updateAuthPlainTextFromSecurityType(getSelectedSecurity());
+            updateViewFromSecurity();
 
             mPortView.removeTextChangedListener(validationTextWatcher);
             mPortView.setText(mCurrentPortViewSetting);
@@ -495,6 +511,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     private void updatePortFromSecurityType() {
         ConnectionSecurity securityType = getSelectedSecurity();
         updateAuthPlainTextFromSecurityType(securityType);
+        updateViewFromSecurity();
 
         // Remove listener so as not to trigger validateFields() which is called
         // elsewhere as a result of user interaction.
@@ -532,9 +549,11 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 String password = null;
                 String clientCertificateAlias = null;
                 AuthType authType = getSelectedAuthType();
-                if (AuthType.EXTERNAL == authType) {
+                if ((ConnectionSecurity.SSL_TLS_REQUIRED == getSelectedSecurity()) ||
+                        (ConnectionSecurity.STARTTLS_REQUIRED == getSelectedSecurity()) ) {
                     clientCertificateAlias = mClientCertificateSpinner.getAlias();
-                } else {
+                }
+                if (AuthType.EXTERNAL != authType) {
                     password = mPasswordView.getText().toString();
                 }
 
@@ -560,9 +579,12 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
             String clientCertificateAlias = null;
 
             AuthType authType = getSelectedAuthType();
-            if (authType == AuthType.EXTERNAL) {
+
+            if ((ConnectionSecurity.SSL_TLS_REQUIRED == connectionSecurity) ||
+                    (ConnectionSecurity.STARTTLS_REQUIRED == connectionSecurity) ) {
                 clientCertificateAlias = mClientCertificateSpinner.getAlias();
-            } else {
+            }
+            if (authType != AuthType.EXTERNAL) {
                 password = mPasswordView.getText().toString();
             }
             String host = mServerView.getText().toString();

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -61,12 +61,13 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     private TextInputEditText mPasswordView;
     private TextInputLayout mPasswordLayoutView;
     private ClientCertificateSpinner mClientCertificateSpinner;
-    private TextView mClientCertificateLabelView;
     private TextInputEditText mServerView;
     private TextInputEditText mPortView;
     private String mCurrentPortViewSetting;
     private CheckBox mRequireLoginView;
     private ViewGroup mRequireLoginSettingsView;
+    private ViewGroup mAllowClientCertificateView;
+
     private Spinner mSecurityTypeView;
     private int mCurrentSecurityTypeViewPosition;
     private Spinner mAuthTypeView;
@@ -119,12 +120,13 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         mUsernameView = findViewById(R.id.account_username);
         mPasswordView = findViewById(R.id.account_password);
         mClientCertificateSpinner = findViewById(R.id.account_client_certificate_spinner);
-        mClientCertificateLabelView = findViewById(R.id.account_client_certificate_label);
         mPasswordLayoutView = findViewById(R.id.account_password_layout);
         mServerView = findViewById(R.id.account_server);
         mPortView = findViewById(R.id.account_port);
         mRequireLoginView = findViewById(R.id.account_require_login);
         mRequireLoginSettingsView = findViewById(R.id.account_require_login_settings);
+        mAllowClientCertificateView = findViewById(R.id.account_allow_client_certificate);
+
         mSecurityTypeView = findViewById(R.id.account_security_type);
         mAuthTypeView = findViewById(R.id.account_auth_type);
         mNextButton = findViewById(R.id.next);
@@ -159,7 +161,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             ServerSettings settings = backendManager.decodeTransportUri(mAccount.getTransportUri());
 
             updateAuthPlainTextFromSecurityType(settings.connectionSecurity);
-
+            updateViewFromSecurity(settings.connectionSecurity);
             if (savedInstanceState == null) {
                 // The first item is selected if settings.authenticationType is null or is not in mAuthTypeAdapter
                 mCurrentAuthTypeViewPosition = mAuthTypeAdapter.getAuthPosition(settings.authenticationType);
@@ -247,7 +249,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
                  */
                 if (mCurrentSecurityTypeViewPosition != position) {
                     updatePortFromSecurityType();
-
+                    updateViewFromSecurity(getSelectedSecurity());
                     boolean isInsecure = (ConnectionSecurity.NONE == getSelectedSecurity());
                     boolean isAuthExternal = (AuthType.EXTERNAL == getSelectedAuthType());
                     boolean loginNotRequired = !mRequireLoginView.isChecked();
@@ -291,9 +293,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
                 validateFields();
                 AuthType selection = getSelectedAuthType();
 
-                // Have the user select (or confirm) the client certificate
-                if (AuthType.EXTERNAL == selection) {
-
+                // Have the user select the client certificate if not already selected
+                if ((AuthType.EXTERNAL == selection) && (mClientCertificateSpinner.getAlias() == null)) {
                     // This may again invoke validateFields()
                     mClientCertificateSpinner.chooseCertificate();
                 } else {
@@ -346,26 +347,34 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     }
 
     /**
-     * Shows/hides password field and client certificate spinner
+     * Shows/hides password field
      */
     private void updateViewFromAuthType() {
         AuthType authType = getSelectedAuthType();
         boolean isAuthTypeExternal = (AuthType.EXTERNAL == authType);
 
         if (isAuthTypeExternal) {
-
-            // hide password fields, show client certificate fields
+            // hide password fields
             mPasswordLayoutView.setVisibility(View.GONE);
-            mClientCertificateLabelView.setVisibility(View.VISIBLE);
-            mClientCertificateSpinner.setVisibility(View.VISIBLE);
         } else {
-
-            // show password fields, hide client certificate fields
+            // show password fields
             mPasswordLayoutView.setVisibility(View.VISIBLE);
-            mClientCertificateLabelView.setVisibility(View.GONE);
-            mClientCertificateSpinner.setVisibility(View.GONE);
         }
     }
+
+    /**
+     * Shows/hides client certificate spinner
+     */
+    private void updateViewFromSecurity(ConnectionSecurity security) {
+        boolean isUsingTLS = ((ConnectionSecurity.SSL_TLS_REQUIRED  == security) || (ConnectionSecurity.STARTTLS_REQUIRED == security));
+
+        if (isUsingTLS) {
+            mAllowClientCertificateView.setVisibility(View.VISIBLE);
+        } else {
+            mAllowClientCertificateView.setVisibility(View.GONE);
+        }
+    }
+
 
     /**
      * This is invoked only when the user makes changes to a widget, not when
@@ -395,6 +404,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             mAuthTypeView.setSelection(mCurrentAuthTypeViewPosition, false);
             mAuthTypeView.setOnItemSelectedListener(onItemSelectedListener);
             updateViewFromAuthType();
+            updateViewFromSecurity(getSelectedSecurity());
 
             onItemSelectedListener = mSecurityTypeView.getOnItemSelectedListener();
             mSecurityTypeView.setOnItemSelectedListener(null);
@@ -476,13 +486,15 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         String password = null;
         String clientCertificateAlias = null;
         AuthType authType = null;
+        if ((ConnectionSecurity.STARTTLS_REQUIRED == securityType) ||
+                (ConnectionSecurity.SSL_TLS_REQUIRED == securityType)) {
+            clientCertificateAlias = mClientCertificateSpinner.getAlias();
+        }
         if (mRequireLoginView.isChecked()) {
             username = mUsernameView.getText().toString();
-
             authType = getSelectedAuthType();
-            if (AuthType.EXTERNAL == authType) {
-                clientCertificateAlias = mClientCertificateSpinner.getAlias();
-            } else {
+
+            if (AuthType.EXTERNAL != authType) {
                 password = mPasswordView.getText().toString();
             }
         }

--- a/app/ui/legacy/src/main/res/layout/account_setup_incoming.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_incoming.xml
@@ -108,23 +108,26 @@
                         android:inputType="textPassword"
                         android:nextFocusDown="@+id/next"/>
             </com.google.android.material.textfield.TextInputLayout>
-
+        <LinearLayout
+            android:id="@+id/account_allow_client_certificate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
             <TextView
-                    android:id="@+id/account_client_certificate_label"
                     android:text="@string/account_setup_incoming_client_certificate_label"
                     android:layout_height="wrap_content"
                     android:layout_width="match_parent"
                     android:layout_marginTop="6dp"
-                    style="@style/InputLabel"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
+                    style="@style/InputLabel"/>
 
             <com.fsck.k9.view.ClientCertificateSpinner
                     android:id="@+id/account_client_certificate_spinner"
                     android:layout_height="wrap_content"
-                    android:layout_width="match_parent"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
+                    android:layout_width="match_parent"/>
+        </LinearLayout>
+
 
             <LinearLayout
                     android:id="@+id/imap_path_prefix_section"

--- a/app/ui/legacy/src/main/res/layout/account_setup_outgoing.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_outgoing.xml
@@ -123,20 +123,27 @@
                         android:nextFocusDown="@+id/next"/>
                 </com.google.android.material.textfield.TextInputLayout>
 
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/account_allow_client_certificate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
                 <TextView
-                    android:id="@+id/account_client_certificate_label"
                     android:text="@string/account_setup_incoming_client_certificate_label"
                     android:layout_height="wrap_content"
                     android:layout_width="match_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:visibility="gone" />
+                    style="@style/InputLabel"
+                    android:layout_marginTop="6dp"/>
 
                 <com.fsck.k9.view.ClientCertificateSpinner
                     android:id="@+id/account_client_certificate_spinner"
                     android:layout_height="wrap_content"
-                    android:layout_width="match_parent"
-                    android:visibility="gone" />
+                    android:layout_width="match_parent" />
             </LinearLayout>
 
             <View


### PR DESCRIPTION
This allows the usage of client certificates to be independent of
authentication.  It is possible that the usage of client certificates
eliminate the need for any authentication, or that they provide
other benifits.

This patch restructures the incoming and outgoing server setup pages
so that client certificates can be set as long as the connection uses
TLS/SSL.  If the user chooses client certificates for authentication
it will prompt for certificate only if there isn't one already set.

Mixing password and client certificates works, and this builds upon
other work that allows these settings to coexist in the imap/smtpURI.

This should address issue: https://github.com/k9mail/k-9/issues/793 